### PR TITLE
Updated newsfeed.js - improved fullscreen iframe

### DIFF
--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -180,10 +180,10 @@ Module.register("newsfeed",{
 			if (this.config.showFullArticle) {
 				var fullArticle = document.createElement("iframe");
 				fullArticle.className = "";
-				fullArticle.style.width = "100%";
+				fullArticle.style.width = "100vw";
 				// very large height value to allow scrolling
-				fullArticle.height = "10000";
-				fullArticle.style.height = "10000";
+				fullArticle.height = "3000";
+				fullArticle.style.height = "3000";
 				fullArticle.style.top = "0";
 				fullArticle.style.left = "0";
 				fullArticle.style.border = "none";
@@ -377,6 +377,13 @@ Module.register("newsfeed",{
 				timer = null;
 				Log.info(this.name + " - showing " + this.config.showDescription ? "article description" : "full article");
 				this.updateDom(100);
+			}
+		} else if(notification == "ARTICLE_SCROLL_UP"){
+			if(this.config.showFullArticle == true){
+				this.scrollPosition -= this.config.scrollLength;
+				window.scrollTo(0, this.scrollPosition);
+				Log.info(this.name + " - scrolling up");
+				Log.info(this.name + " - ARTICLE_SCROLL_UP, scroll position: " + this.config.scrollLength);
 			}
 		} else if(notification == "ARTICLE_LESS_DETAILS"){
 			this.resetDescrOrFullArticleAndTimer();


### PR DESCRIPTION
Had much better performance using 100vw (viewport width) than 100% (why - idk), but with 100% about 5% of my screen (1080x1920) to the right of the scroll bar was left black/blank, with 100vw I legitimately takes up the whole screen/viewport width. 

With the 10000 height the articles would always load about half way scrolled down. So I reduced the height and style.height to 3000. At my resolution at least, which I assume is fairly common, I had much better results. Unfortunately 3000 also isn't perfect - this still requires some tweaking. The article loads perfectly at the top of the iframe at 2500, but 2500 is much too small for most articles. 3000 seemed a good compromise, I could scroll far enoguh to read most articles on Reuters, and also load far enoguh up to read the beginning of the article.

And finally I added a "scroll back up" button notification. This seems to work flawlessly.

> Please send your pull requests the develop branch.
> Don't forget to add the change to CHANGELOG.md.

**Note**: Sometimes the development moves very fast. It is highly
recommended that you update your branch of `develop` before creating a
pull request to send us your changes. This makes everyone's lives
easier (including yours) and helps us out on the development team.
Thanks!


* Does the pull request solve a **related** issue?
* If so, can you reference the issue?
* What does the pull request accomplish? Use a list if needed.
* If it includes major visual changes please add screenshots.
